### PR TITLE
adds "required" to inputs

### DIFF
--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -39,6 +39,8 @@ defmodule Autoform do
             :update -> Enum.find(assigns, fn {_k, v} -> match?(v, schema) end)
           end
 
+        required = Map.get(schema.changeset(struct(schema), %{}), :required)
+
         action = path(conn, action, schema_data)
 
         assigns =
@@ -46,6 +48,7 @@ defmodule Autoform do
           |> Enum.into(%{})
           |> Map.put(:action, action)
           |> Map.put(:fields, fields)
+          |> Map.put(:required, required)
 
         cond do
           Regex.match?(~r/.+Controller$/, to_string(__MODULE__)) ->

--- a/lib/templates/autoform/form.html.eex
+++ b/lib/templates/autoform/form.html.eex
@@ -6,8 +6,8 @@
   <% end %>
   <%= for field <- @fields do %>
     <div class="form-group">
-      <%= label f, field, class: "control-label" %>
-      <%= input f, field, class: "form-control" %>
+      <%= label f, field, class: "control-label #{if field in @required do "required" end}" %>
+      <%= input f, field, class: "form-control", required: (field in @required) %>
       <%= error_tag f, field %>
     </div>
   <% end %>


### PR DESCRIPTION
If fields are in `validate_required` function in a schema's changeset:

- Adds 'required' to input
- Adds class of 'required' to label