### PR TITLE
Associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
 # af
 Auto Form ("af") is a way of generating standards/WCAG compliant HTML forms based on an Ecto Schema.
+
+## Usage
+
+Add autoform to your mix.exs
+
+``` elixir
+defp deps do
+    [
+      {:autoform, "~> 0.1.0"}
+    ]
+  end
+```
+
+Autoform can be used from either a Phoenix View, or Phoenix Controller.
+
+You'll need to add
+``` elixir
+use Autoform
+```
+
+to the top of the module you want to use it in.
+
+Then, you'll have the `render_autoform/4` function available in the controller, or the template that corresponds to the view.
+
+Call the function in your controller with:
+
+``` elixir
+render_autoform(conn, :update, User, assigns: [user: get_user_from_db()])
+```
+
+or in your template:
+``` elixir
+<%= render_autoform(@conn, :new, User, assigns: [changeset: @changeset)], exclude: :date_of_birth %>
+```
+
+### Arguments
+
+``` elixir
+render_autoform(conn, action, schema, options)
+```
+
+- conn : Your Phoenix Plug.Conn
+
+- action : Either `:update` or `:create`. This will be used to create the endpoint for your form.
+
+- schema : Your Ecto schema
+
+- options : A list of options you can use to customise your forms.
+  - `:assigns` - The assigns for the form template, for example a changeset for update forms. Will default to empty list
+  - `:exclude` - A list of any fields in your schema you don't want to display on the form
+  -  `:update_field` - The field from your schema you want to use in your update path (/users/some-id), defaults to `id`
+  - `:assoc_query` - An ecto query you want to use when loading your associations

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -20,7 +20,7 @@ defmodule Autoform do
       import Ecto.Query, only: [from: 2]
 
       @doc """
-        Renders a 'new' or 'update' form based on the schema passed to it.
+        Renders a 'create' or 'update' form based on the schema passed to it.
 
         ## Examples
 
@@ -30,7 +30,7 @@ defmodule Autoform do
 
           In a template:
 
-            <%= render_autoform(@conn, :new, User, assigns: [changeset: @changeset)], exclude: :date_of_birth %>
+            <%= render_autoform(@conn, :create, User, assigns: [changeset: @changeset)], exclude: :date_of_birth %>
 
         ## Options
 

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -121,11 +121,14 @@ defmodule Autoform do
 
             %{
               name: a,
-              associations: apply(repo, :all, [assoc])
+              associations:
+                Enum.map(apply(repo, :all, [assoc]), fn a ->
+                  Map.put(a, :display, Map.get(a, :name, Map.get(a, :type, "test")))
+                end)
             }
           end)
 
-        Map.put(assigns, :associations, associations)
+        Map.put(assigns, :associations, IO.inspect(associations))
       end
     end
   end

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -17,6 +17,8 @@ defmodule Autoform do
   """
   defmacro __using__(_opts) do
     quote location: :keep do
+      import Ecto.Query, only: [from: 2]
+
       @doc """
         Renders a 'new' or 'update' form based on the schema passed to it.
 
@@ -34,6 +36,8 @@ defmodule Autoform do
 
           * `:assigns` - The assigns for the form template, for example a changeset for update forms. Will default to empty list
           * `:exclude` - A list of any fields in your schema you don't want to display on the form
+          * `:update_field` - The field from your schema you want to use in your update path (/users/some-id), defaults to id
+          * `:assoc_query` - An ecto query you want to use when loading your associations
 
       """
       @spec render_autoform(
@@ -46,15 +50,26 @@ defmodule Autoform do
           when action in [:update, :create] do
         assigns = Keyword.get(options, :assigns, [])
 
-        {_key, schema_data} =
+        path_data =
           case action do
-            :create -> {nil, []}
-            :update -> Enum.find(assigns, fn {_k, v} -> match?(v, schema) end)
+            :create ->
+              []
+
+            :update ->
+              {key, schema_data} =
+                Enum.find(assigns, fn {k, v} ->
+                  k != :changeset && match?(v, schema)
+                end)
+
+              case Keyword.get(options, :update_field) do
+                nil -> schema_data
+                field -> Map.get(schema_data, field)
+              end
           end
 
         required = Map.get(schema.changeset(struct(schema), %{}), :required)
 
-        action = path(conn, action, schema_data)
+        action = path(conn, action, path_data)
 
         assigns =
           assigns
@@ -107,6 +122,11 @@ defmodule Autoform do
       defp put_associations(assigns, conn, schema, options) do
         excludes = Keyword.get(options, :exclude, [])
 
+        assoc_query =
+          Keyword.get(options, :assoc_query, fn schema -> from(s in schema, select: s) end)
+
+        ch = Map.get(assigns, :changeset).data
+
         repo =
           Module.concat(
             Macro.camelize(to_string(Phoenix.Controller.endpoint_module(conn).config(:otp_app))),
@@ -119,12 +139,22 @@ defmodule Autoform do
           |> Enum.map(fn a ->
             assoc = Map.get(schema.__schema__(:association, a), :queryable)
 
+            query =
+              case is_function(assoc_query) do
+                true -> assoc_query.(assoc)
+                false -> nil
+              end
+
             %{
               name: a,
               associations:
-                Enum.map(apply(repo, :all, [assoc]), fn a ->
-                  Map.put(a, :display, Map.get(a, :name, Map.get(a, :type, "test")))
-                end)
+                Enum.map(
+                  apply(repo, :all, [query]),
+                  fn a ->
+                    Map.put(a, :display, Map.get(a, :name))
+                  end
+                ),
+              loaded_associations: apply(repo, :preload, [ch, [{a, query}]])
             }
           end)
 

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -20,19 +20,31 @@ defmodule Autoform do
       @doc """
         Renders a 'new' or 'update' form based on the schema passed to it.
 
-        Example:
+        ## Examples
+
           In a controller:
-            render_autoform(conn, :update, User, user: get_user_from_db())
+
+            render_autoform(conn, :update, User, assigns: [user: get_user_from_db()])
 
           In a template:
-            <%= render_autoform(@conn, :new, User, changeset: @changeset) %>
+
+            <%= render_autoform(@conn, :new, User, assigns: [changeset: @changeset)], exclude: :date_of_birth %>
+
+        ## Options
+
+          * `:assigns` - The assigns for the form template, for example a changeset for update forms. Will default to empty list
+          * `:exclude` - Any fields in your schema you don't want to display on the form
+
       """
-      @spec render_autoform(Plug.Conn.t(), atom, Ecto.Schema.t(), Keyword.t() | map) ::
-              Plug.Conn.t()
-      def render_autoform(conn, action, schema, assigns) when action in [:update, :create] do
-        fields =
-          schema.__schema__(:fields)
-          |> Enum.reject(&(&1 in [:id, :inserted_at, :updated_at]))
+      @spec render_autoform(
+              Plug.Conn.t(),
+              atom,
+              Ecto.Schema.t(),
+              Keyword.t() | map
+            ) :: Plug.Conn.t() | {atom, String.t()} | no_return()
+      def render_autoform(conn, action, schema, options \\ [])
+          when action in [:update, :create] do
+        assigns = Keyword.get(options, :assigns, [])
 
         {_key, schema_data} =
           case action do
@@ -48,9 +60,9 @@ defmodule Autoform do
           assigns
           |> Enum.into(%{})
           |> Map.put(:action, action)
-          |> Map.put(:fields, fields)
+          |> put_fields(schema, options)
           |> Map.put(:required, required)
-          |> put_associations(conn, schema)
+          |> put_associations(conn, schema, options)
           |> Map.put(
             :schema_name,
             to_string(schema) |> String.downcase() |> String.split(".") |> List.last()
@@ -83,7 +95,17 @@ defmodule Autoform do
         )
       end
 
-      defp put_associations(assigns, conn, schema) do
+      defp put_fields(assigns, schema, options) do
+        excludes = Keyword.get(options, :exclude, []) ++ [:id, :inserted_at, :updated_at]
+
+        fields = schema.__schema__(:fields) |> Enum.reject(&(&1 in excludes))
+
+        Map.put(assigns, :fields, fields)
+      end
+
+      defp put_associations(assigns, conn, schema, options) do
+        excludes = Keyword.get(options, :exclude, [])
+
         repo =
           Module.concat(
             Macro.camelize(to_string(Phoenix.Controller.endpoint_module(conn).config(:otp_app))),
@@ -91,7 +113,9 @@ defmodule Autoform do
           )
 
         associations =
-          Enum.map(schema.__schema__(:associations), fn a ->
+          schema.__schema__(:associations)
+          |> Enum.reject(&(&1 in excludes))
+          |> Enum.map(fn a ->
             assoc = Map.get(schema.__schema__(:association, a), :queryable)
 
             %{

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -59,6 +59,7 @@ defmodule Autoform do
         assigns =
           assigns
           |> Enum.into(%{})
+          |> Map.put_new(:changeset, schema.changeset(struct(schema), %{}))
           |> Map.put(:action, action)
           |> put_fields(schema, options)
           |> Map.put(:required, required)

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -33,7 +33,7 @@ defmodule Autoform do
         ## Options
 
           * `:assigns` - The assigns for the form template, for example a changeset for update forms. Will default to empty list
-          * `:exclude` - Any fields in your schema you don't want to display on the form
+          * `:exclude` - A list of any fields in your schema you don't want to display on the form
 
       """
       @spec render_autoform(
@@ -128,7 +128,7 @@ defmodule Autoform do
             }
           end)
 
-        Map.put(assigns, :associations, IO.inspect(associations))
+        Map.put(assigns, :associations, associations)
       end
     end
   end

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -1,0 +1,24 @@
+defmodule Autoform.Gettext do
+  @moduledoc """
+  A module providing Internationalization with a gettext-based API.
+
+  By using [Gettext](https://hexdocs.pm/gettext),
+  your module gains a set of macros for translations, for example:
+
+      import CsGuideWeb.Gettext
+
+      # Simple translation
+      gettext "Here is the string to translate"
+
+      # Plural translation
+      ngettext "Here is the string to translate",
+               "Here are the strings to translate",
+               3
+
+      # Domain-based translation
+      dgettext "errors", "Here is the error message to translate"
+
+  See the [Gettext Docs](https://hexdocs.pm/gettext) for detailed usage.
+  """
+  use Gettext, otp_app: :autoform
+end

--- a/lib/templates/autoform/form.html.eex
+++ b/lib/templates/autoform/form.html.eex
@@ -11,6 +11,13 @@
       <%= error_tag f, field %>
     </div>
   <% end %>
+  <%= for assoc <- @associations do %>
+    <%= label f, assoc[:name], class: "control-label" %>
+    <%= for a <- assoc[:associations] do %>
+      <input type="checkbox" id="<%=@schema_name%>_<%=assoc[:name]%>_<%=String.to_atom(Map.get(a, :type))%>" name="<%=@schema_name%>[<%=assoc[:name]%>][<%=String.to_atom(Map.get(a, :type))%>]" class="form-control">
+      <label for="<%=@schema_name%>_<%=assoc[:name]%>_<%=String.to_atom(Map.get(a, :type))%>"><%= Map.get(a, :type) |> String.capitalize() %></label>
+    <% end %>
+  <% end %>
 
   <div class="form-group">
     <%= submit "Submit", class: "btn btn-primary" %>

--- a/lib/templates/autoform/form.html.eex
+++ b/lib/templates/autoform/form.html.eex
@@ -12,11 +12,13 @@
     </div>
   <% end %>
   <%= for assoc <- @associations do %>
-    <%= label f, assoc[:name], class: "control-label" %>
-    <%= for a <- assoc[:associations] do %>
-      <input type="checkbox" id="<%=@schema_name%>_<%=assoc[:name]%>_<%=String.to_atom(Map.get(a, :type))%>" name="<%=@schema_name%>[<%=assoc[:name]%>][<%=String.to_atom(Map.get(a, :type))%>]" class="form-control">
-      <label for="<%=@schema_name%>_<%=assoc[:name]%>_<%=String.to_atom(Map.get(a, :type))%>"><%= Map.get(a, :type) |> String.capitalize() %></label>
-    <% end %>
+    <div class="form-group <%= assoc[:name] %>-group">
+      <%= label f, assoc[:name], class: "control-label" %>
+      <%= for a <- assoc[:associations] do %>
+        <input type="checkbox" id="<%=@schema_name%>_<%=assoc[:name]%>_<%=String.split(Map.get(a, :display)) |> Enum.join |> Macro.underscore()%>" name="<%=@schema_name%>[<%=assoc[:name]%>][<%=String.to_atom(Map.get(a, :display))%>]" class="form-control">
+        <label for="<%=@schema_name%>_<%=assoc[:name]%>_<%=String.to_atom(Map.get(a, :display))%>"><%= Map.get(a, :display) |> String.capitalize() %></label>
+      <% end %>
+    </div>
   <% end %>
 
   <div class="form-group">

--- a/lib/templates/autoform/form.html.eex
+++ b/lib/templates/autoform/form.html.eex
@@ -15,7 +15,13 @@
     <div class="form-group <%= assoc[:name] %>-group">
       <%= label f, assoc[:name], class: "control-label" %>
       <%= for a <- assoc[:associations] do %>
-        <input type="checkbox" id="<%=@schema_name%>_<%=assoc[:name]%>_<%=String.split(Map.get(a, :display)) |> Enum.join |> Macro.underscore()%>" name="<%=@schema_name%>[<%=assoc[:name]%>][<%=String.to_atom(Map.get(a, :display))%>]" class="form-control">
+        <input 
+          type="checkbox" 
+          id="<%=@schema_name%>_<%=assoc[:name]%>_<%=String.split(Map.get(a, :display)) |> Enum.join |> Macro.underscore()%>"
+          name="<%=@schema_name%>[<%=assoc[:name]%>][<%=String.to_atom(Map.get(a, :display))%>]" 
+          class="form-control"
+          <%= if Map.get(assoc.loaded_associations, assoc[:name]) |> Enum.find(fn l -> Map.get(l, :name) == Map.get(a, :display) || Map.get(l, :type) == Map.get(a, :display) end) do "checked" end%>
+          >
         <label for="<%=@schema_name%>_<%=assoc[:name]%>_<%=String.to_atom(Map.get(a, :display))%>"><%= Map.get(a, :display) |> String.capitalize() %></label>
       <% end %>
     </div>

--- a/lib/views/error_helpers.ex
+++ b/lib/views/error_helpers.ex
@@ -36,9 +36,9 @@ defmodule Autoform.ErrorHelpers do
     # should be written to the errors.po file. The :count option is
     # set by Ecto and indicates we should also apply plural rules.
     if count = opts[:count] do
-      Gettext.dngettext(ReusableWeb.Gettext, "errors", msg, msg, count, opts)
+      Gettext.dngettext(Autoform.Gettext, "errors", msg, msg, count, opts)
     else
-      Gettext.dgettext(ReusableWeb.Gettext, "errors", msg, opts)
+      Gettext.dgettext(Autoform.Gettext, "errors", msg, opts)
     end
   end
 end

--- a/test/autoform_controller_test.exs
+++ b/test/autoform_controller_test.exs
@@ -10,6 +10,7 @@ defmodule AutoformControllerTest do
                |> html_response(200)
 
       assert response =~ "age"
+      assert response =~ "address"
       assert response =~ "name"
     end
 
@@ -39,7 +40,7 @@ defmodule AutoformControllerTest do
                |> get(user_path(conn, :edit, 1))
                |> html_response(200)
 
-      assert response =~ "age"
+      assert response =~ "address"
       assert response =~ "name"
     end
 
@@ -50,7 +51,7 @@ defmodule AutoformControllerTest do
                |> html_response(200)
 
       assert response =~ "Test User"
-      assert response =~ "55"
+      assert response =~ "12 Test Road"
     end
 
     test "Correct form action", %{conn: conn} do
@@ -60,6 +61,15 @@ defmodule AutoformControllerTest do
                |> html_response(200)
 
       assert response =~ ~s(action="/users/1")
+    end
+
+    test "Excluded fields do not display", %{conn: conn} do
+      assert response =
+               conn
+               |> get(user_path(conn, :edit, 1))
+               |> html_response(200)
+
+      refute response =~ "age"
     end
   end
 end

--- a/test/autoform_view_test.exs
+++ b/test/autoform_view_test.exs
@@ -20,5 +20,14 @@ defmodule AutoformViewTest do
 
       assert response =~ "Addresses"
     end
+
+    test "Excluded fields do not display", %{conn: conn} do
+      assert response =
+               conn
+               |> get(address_path(conn, :new))
+               |> html_response(200)
+
+      refute response =~ "Line 1"
+    end
   end
 end

--- a/test/support/test_autoform/lib/test_autoform/user.ex
+++ b/test/support/test_autoform/lib/test_autoform/user.ex
@@ -5,6 +5,7 @@ defmodule TestAutoform.User do
   schema "users" do
     field(:age, :integer)
     field(:name, :string)
+    field(:address, :string)
 
     timestamps()
   end

--- a/test/support/test_autoform/lib/test_autoform_web/controllers/user_controller.ex
+++ b/test/support/test_autoform/lib/test_autoform_web/controllers/user_controller.ex
@@ -11,10 +11,10 @@ defmodule TestAutoformWeb.UserController do
   end
 
   def edit(conn, %{"id" => id}) do
-    user = %User{name: "Test User", age: "55", id: id}
+    user = %User{name: "Test User", age: "55", address: "12 Test Road", id: id}
     changeset = User.changeset(user, %{})
 
     conn
-    |> render_autoform(:update, User, assigns: [user: user, changeset: changeset])
+    |> render_autoform(:update, User, assigns: [user: user, changeset: changeset], exclude: [:age])
   end
 end

--- a/test/support/test_autoform/lib/test_autoform_web/controllers/user_controller.ex
+++ b/test/support/test_autoform/lib/test_autoform_web/controllers/user_controller.ex
@@ -7,7 +7,7 @@ defmodule TestAutoformWeb.UserController do
   def new(conn, _params) do
     changeset = User.changeset(%User{}, %{})
 
-    render_autoform(conn, :create, User, changeset: changeset)
+    render_autoform(conn, :create, User, assigns: [changeset: changeset])
   end
 
   def edit(conn, %{"id" => id}) do
@@ -15,6 +15,6 @@ defmodule TestAutoformWeb.UserController do
     changeset = User.changeset(user, %{})
 
     conn
-    |> render_autoform(:update, User, user: user, changeset: changeset)
+    |> render_autoform(:update, User, assigns: [user: user, changeset: changeset])
   end
 end

--- a/test/support/test_autoform/lib/test_autoform_web/templates/address/new.html.eex
+++ b/test/support/test_autoform/lib/test_autoform_web/templates/address/new.html.eex
@@ -1,3 +1,3 @@
 <h1>Addresses</h1>
 
-<%= render_autoform @conn, :create, TestAutoform.Address, changeset: @changeset %>
+<%= render_autoform @conn, :create, TestAutoform.Address, assigns: [changeset: @changeset] %>

--- a/test/support/test_autoform/lib/test_autoform_web/templates/address/new.html.eex
+++ b/test/support/test_autoform/lib/test_autoform_web/templates/address/new.html.eex
@@ -1,3 +1,3 @@
 <h1>Addresses</h1>
 
-<%= render_autoform @conn, :create, TestAutoform.Address, assigns: [changeset: @changeset] %>
+<%= render_autoform @conn, :create, TestAutoform.Address, assigns: [changeset: @changeset], exclude: [:line_1] %>


### PR DESCRIPTION
ref #11 

- Displays associations as checkboxes in form.
- Existing associations are displayed as correctly checked checboxes
- Allows fields to be optionally excluded

Version 0.1.0 will be ready for publish once this is merged