### PR TITLE
adds ability to customise labels

### DIFF
--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -126,11 +126,14 @@ defmodule Autoform do
                 %{html: Phoenix.HTML.raw(e)}
 
               false ->
-                {schema, excludes} =
+                {schema, schema_options} =
                   case e do
-                    {schema, opts} -> {schema, Keyword.get(opts, :exclude, [])}
+                    {schema, opts} -> {schema, opts}
                     _ -> {e, []}
                   end
+
+                excludes = Keyword.get(schema_options, :exclude, [])
+                custom_labels = Keyword.get(schema_options, :custom_labels, %{})
 
                 %{
                   fields:
@@ -148,7 +151,8 @@ defmodule Autoform do
                       schema.changeset(struct(schema), %{}),
                       Keyword.update(options, :exclude, [], fn v -> v ++ excludes end)
                     ),
-                  schema_name: schema_name(schema)
+                  schema_name: schema_name(schema),
+                  custom_labels: custom_labels
                 }
             end
           end)

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -93,7 +93,7 @@ defmodule Autoform do
             <%= custom_render_autoform(@conn, :create, [
               User,
               "<h1>Title goes here</h1>",
-              {Address, exclude: [:line_2]}
+              {Address, exclude: [:line_2], custom_labels: %{line_1: "Street Name"}}
             ], assigns: [changeset: @changeset)], exclude: [:entry_id] %>
 
         ## Schema Options
@@ -101,6 +101,7 @@ defmodule Autoform do
         Pass these as the second element in a tuple, where the schema is the first.
 
           * `:exclude` - A list of any fields from this schema you don't want to display.
+          * `:custom_labels` - A map where the key is your field name, and the value is what you want to display as the label for that field.
 
         ## Global Options
 

--- a/lib/templates/custom/custom.html.eex
+++ b/lib/templates/custom/custom.html.eex
@@ -6,7 +6,8 @@
       <%= for field <- element.fields do %>
         <div class="form-group">
           <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %>
-            <%= if Map.get(element.custom_labels, field) do Map.get(element.custom_labels, field) else humanize(field) end %>
+            <% custom_label = Map.get(element.custom_labels, field) %>
+            <%= custom_label || humanize(field) %>
           <% end %>
           <%= input f, field, element.schema_name, class: "form-control", required: (field in element.required) %>
           <%= error_tag f, field %>

--- a/lib/templates/custom/custom.html.eex
+++ b/lib/templates/custom/custom.html.eex
@@ -5,7 +5,9 @@
     <% else %>
       <%= for field <- element.fields do %>
         <div class="form-group">
-          <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" %>
+          <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %>
+            <%= if Map.get(element.custom_labels, field) do Map.get(element.custom_labels, field) else humanize(field) end %>
+          <% end %>
           <%= input f, field, element.schema_name, class: "form-control", required: (field in element.required) %>
           <%= error_tag f, field %>
         </div>

--- a/test/custom_test.exs
+++ b/test/custom_test.exs
@@ -72,5 +72,15 @@ defmodule CustomTest do
 
       assert response =~ "/custom"
     end
+
+    test "labels are replaced with custom options", %{conn: conn} do
+      assert response =
+               conn
+               |> get(custom_path(conn, :new))
+               |> html_response(200)
+
+      assert response =~ "Years on Earth"
+      refute response =~ "Age"
+    end
   end
 end

--- a/test/support/test_autoform/lib/test_autoform_web/templates/custom/new.html.eex
+++ b/test/support/test_autoform/lib/test_autoform_web/templates/custom/new.html.eex
@@ -3,5 +3,6 @@
 <%= custom_render_autoform(@conn, :create, [
   TestAutoform.Address,
   "<h1>Between address and user</h1>",
-  {TestAutoform.User, exclude: [:age]}
+  {TestAutoform.User, exclude: [:age]},
+  {TestAutoform.User, exclude: [:name, :address], custom_labels: %{age: "Years on Earth"}}
 ], path: "/endpoint") %>


### PR DESCRIPTION
ref #18

You can now pass in a map of custom labels if your schema field name is not what you want to display on your form.