### PR TITLE
allows users to specify the order of input and label #20

### DIFF
--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -102,6 +102,7 @@ defmodule Autoform do
 
           * `:exclude` - A list of any fields from this schema you don't want to display.
           * `:custom_labels` - A map where the key is your field name, and the value is what you want to display as the label for that field.
+          * `:input_first` - A list of any fields from this schema where you would like to display the input followed by the label.
 
         ## Global Options
 
@@ -135,6 +136,7 @@ defmodule Autoform do
 
                 excludes = Keyword.get(schema_options, :exclude, [])
                 custom_labels = Keyword.get(schema_options, :custom_labels, %{})
+                input_first = Keyword.get(schema_options, :input_first, [])
 
                 %{
                   fields:
@@ -153,7 +155,8 @@ defmodule Autoform do
                       Keyword.update(options, :exclude, [], fn v -> v ++ excludes end)
                     ),
                   schema_name: schema_name(schema),
-                  custom_labels: custom_labels
+                  custom_labels: custom_labels,
+                  input_first: input_first
                 }
             end
           end)

--- a/lib/templates/custom/custom.html.eex
+++ b/lib/templates/custom/custom.html.eex
@@ -5,22 +5,31 @@
     <% else %>
       <%= for field <- element.fields do %>
         <div class="form-group">
-          <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %>
-            <% custom_label = Map.get(element.custom_labels, field) %>
-            <%= custom_label || humanize(field) %>
+          <%= if Map.has_key?(element, :input_first) && Enum.any?(element.input_first, &(&1 == field)) do %>
+            <%= input f, field, element.schema_name, class: "form-control", required: (field in element.required) %>
+            <%= error_tag f, field %>
+            <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %>
+              <% custom_label = Map.get(element.custom_labels, field) %>
+              <%= custom_label || humanize(field) %>
+            <% end %>
+          <% else %>
+            <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %>
+              <% custom_label = Map.get(element.custom_labels, field) %>
+              <%= custom_label || humanize(field) %>
+            <% end %>
+            <%= input f, field, element.schema_name, class: "form-control", required: (field in element.required) %>
+            <%= error_tag f, field %>
           <% end %>
-          <%= input f, field, element.schema_name, class: "form-control", required: (field in element.required) %>
-          <%= error_tag f, field %>
         </div>
       <% end %>
       <%= for assoc <- element.associations do %>
         <div class="form-group <%= assoc[:name] %>-group">
           <%= label String.to_existing_atom(element.schema_name), assoc[:name], class: "control-label" %>
           <%= for a <- assoc[:associations] do %>
-            <input 
-              type="checkbox" 
+            <input
+              type="checkbox"
               id="<%=element.schema_name%>_<%=assoc[:name]%>_<%=String.split(Map.get(a, :display)) |> Enum.join |> Macro.underscore()%>"
-              name="<%=element.schema_name%>[<%=assoc[:name]%>][<%=String.to_atom(Map.get(a, :display))%>]" 
+              name="<%=element.schema_name%>[<%=assoc[:name]%>][<%=String.to_atom(Map.get(a, :display))%>]"
               class="form-control"
               <%= if Map.get(assoc.loaded_associations, assoc[:name]) |> Enum.find(fn l -> Map.get(l, :name) == Map.get(a, :display) || Map.get(l, :type) == Map.get(a, :display) end) do "checked" end%>
               >

--- a/test/autoform_view_test.exs
+++ b/test/autoform_view_test.exs
@@ -29,5 +29,14 @@ defmodule AutoformViewTest do
 
       refute response =~ "Line 1"
     end
+
+    test "Reverse order of :line_1 input box and label", %{conn: conn} do
+      response = conn |> get(address_path(conn, :index)) |> html_response(200)
+      [h, t] = Regex.split(~r{id=\"address_line_1\"}, response)
+
+      assert response =~ "id=\"address_line_1\""
+      refute h =~ "for=\"address_line_1\""
+      assert t =~ "for=\"address_line_1\""
+    end
   end
 end

--- a/test/support/test_autoform/lib/test_autoform_web/controllers/address_controller.ex
+++ b/test/support/test_autoform/lib/test_autoform_web/controllers/address_controller.ex
@@ -2,6 +2,12 @@ defmodule TestAutoformWeb.AddressController do
   use TestAutoformWeb, :controller
   alias TestAutoform.Address
 
+  def index(conn, _params) do
+    changeset = Address.changeset(%Address{}, %{})
+
+    render(conn, "index.html", changeset: changeset)
+  end
+
   def new(conn, _params) do
     changeset = Address.changeset(%Address{}, %{})
 

--- a/test/support/test_autoform/lib/test_autoform_web/templates/address/index.html.eex
+++ b/test/support/test_autoform/lib/test_autoform_web/templates/address/index.html.eex
@@ -1,0 +1,1 @@
+<%= custom_render_autoform @conn, :create, [{TestAutoform.Address, input_first: [:line_1]}], assigns: [changeset: @changeset] %>


### PR DESCRIPTION
Allows users to specify the order of input and label #20

@Danwhy I tried to write the code in the same way as what was there. If you want me to change anything style/syntax wise then please let me know. 