### PR TITLE
displays changeset from assigns correctly

### DIFF
--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -172,7 +172,8 @@ defmodule Autoform do
           Autoform.CustomView,
           "custom.html",
           Keyword.get(options, :assigns, %{})
-          |> Enum.into(%{})
+          |> Map.new()
+          |> Map.put_new(:changeset, first_schema.changeset(struct(first_schema), %{}))
           |> Map.merge(%{
             elements: element_assigns,
             action: Keyword.get(options, :path, path(conn, action, first_schema, options))

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -171,11 +171,12 @@ defmodule Autoform do
         Phoenix.View.render(
           Autoform.CustomView,
           "custom.html",
-          %{
+          Keyword.get(options, :assigns, %{})
+          |> Enum.into(%{})
+          |> Map.merge(%{
             elements: element_assigns,
-            changeset: first_schema.changeset(struct(first_schema), %{}),
             action: Keyword.get(options, :path, path(conn, action, first_schema, options))
-          }
+          })
         )
       end
 

--- a/lib/templates/custom/custom.html.eex
+++ b/lib/templates/custom/custom.html.eex
@@ -31,7 +31,7 @@
               id="<%=element.schema_name%>_<%=assoc[:name]%>_<%=String.split(Map.get(a, :display)) |> Enum.join |> Macro.underscore()%>"
               name="<%=element.schema_name%>[<%=assoc[:name]%>][<%=String.to_atom(Map.get(a, :display))%>]"
               class="form-control"
-              <%= if Map.get(assoc.loaded_associations, assoc[:name]) |> Enum.find(fn l -> Map.get(l, :name) == Map.get(a, :display) || Map.get(l, :type) == Map.get(a, :display) end) do "checked" end%>
+              <%= if (Map.get(assoc.loaded_associations, assoc[:name]) || []) |> Enum.find(fn l -> Map.get(l, :name) == Map.get(a, :display) || Map.get(l, :type) == Map.get(a, :display) end) do "checked" end%>
               >
             <label for="<%=element.schema_name%>_<%=assoc[:name]%>_<%=String.to_atom(Map.get(a, :display))%>"><%= Map.get(a, :display) |> String.capitalize() %></label>
           <% end %>


### PR DESCRIPTION
Uses the correct changeset for `custom_render_autoform` when it's passed in (as it always did for `render_autoform`)