### PR TITLE
Dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,11 @@ custom_render_autoform(conn, action, [{schema, opts}], options)
   - `:exclude` - A list of any fields in your schema you don't want to display on the form
   -  `:update_field` - The field from your schema you want to use in your update path (/users/some-id), defaults to `id`
   - `:assoc_query` - An ecto query you want to use when loading your associations
+
+### Associations
+
+`:many_to_many` associations are rendered as checkboxes.
+
+`:belongs_to` associations are rendered as a `select` element.
+
+If you don't want the associations to be rendered in your form, you can add them to your exclude list (see options `above`).

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -247,6 +247,7 @@ defmodule Autoform do
               end
 
             %{
+              cardinality: Map.get(schema.__schema__(:association, a), :cardinality),
               name: a,
               associations:
                 Enum.map(

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -223,7 +223,8 @@ defmodule Autoform do
       defp fields(schema, options) do
         excludes = Keyword.get(options, :exclude, []) ++ unquote(@excludes)
 
-        schema.__schema__(:fields) |> Enum.reject(&(&1 in excludes))
+        schema.__schema__(:fields)
+        |> Enum.reject(&(&1 in excludes))
       end
 
       defp associations(conn, schema, changeset, options) do

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -154,7 +154,11 @@ defmodule Autoform do
                     associations(
                       conn,
                       schema,
-                      schema.changeset(struct(schema), %{}),
+                      Keyword.get(
+                        Keyword.get(options, :assigns, []),
+                        :changeset,
+                        schema.changeset(struct(schema), %{})
+                      ),
                       Keyword.update(options, :exclude, [], fn v -> v ++ excludes end)
                     ),
                   schema_name: schema_name(schema),
@@ -174,7 +178,7 @@ defmodule Autoform do
         Phoenix.View.render(
           Autoform.CustomView,
           "custom.html",
-          Keyword.get(options, :assigns, %{})
+          Keyword.get(options, :assigns, [])
           |> Map.new()
           |> Map.put_new(:changeset, first_schema.changeset(struct(first_schema), %{}))
           |> Map.merge(%{

--- a/lib/templates/autoform/form.html.eex
+++ b/lib/templates/autoform/form.html.eex
@@ -13,7 +13,7 @@
   <% end %>
   <%= for assoc <- @associations do %>
     <div class="form-group <%= assoc[:name] %>-group">
-      <%= label f, assoc[:name], class: "control-label" %>
+      <%= label f, assoc[:name], class: "control-label #{if assoc[:name] in @required do "required" end}" %>
       <%= for a <- assoc[:associations] do %>
         <input 
           type="checkbox" 

--- a/lib/templates/autoform/form.html.eex
+++ b/lib/templates/autoform/form.html.eex
@@ -24,6 +24,7 @@
           >
         <label for="<%=@schema_name%>_<%=assoc[:name]%>_<%=String.to_atom(Map.get(a, :display))%>"><%= Map.get(a, :display) |> String.capitalize() %></label>
       <% end %>
+      <%= error_tag f, assoc[:name] %>
     </div>
   <% end %>
 

--- a/lib/templates/custom/custom.html.eex
+++ b/lib/templates/custom/custom.html.eex
@@ -25,15 +25,27 @@
       <%= for assoc <- element.associations do %>
         <div class="form-group <%= assoc[:name] %>-group">
           <%= label String.to_existing_atom(element.schema_name), assoc[:name], class: "control-label" %>
-          <%= for a <- assoc[:associations] do %>
-            <input
-              type="checkbox"
-              id="<%=element.schema_name%>_<%=assoc[:name]%>_<%=String.split(Map.get(a, :display)) |> Enum.join |> Macro.underscore()%>"
-              name="<%=element.schema_name%>[<%=assoc[:name]%>][<%=String.to_atom(Map.get(a, :display))%>]"
-              class="form-control"
-              <%= if (Map.get(assoc.loaded_associations, assoc[:name]) || []) |> Enum.find(fn l -> Map.get(l, :name) == Map.get(a, :display) || Map.get(l, :type) == Map.get(a, :display) end) do "checked" end%>
-              >
-            <label for="<%=element.schema_name%>_<%=assoc[:name]%>_<%=String.to_atom(Map.get(a, :display))%>"><%= Map.get(a, :display) |> String.capitalize() %></label>
+          <%= if assoc[:cardinality] == :one do %>
+            <select name="<%=element.schema_name%>[<%=assoc[:name]%>]">
+              <%= for a <- assoc[:associations] do %>
+                <option value="<%=String.to_atom(Map.get(a, :display))%>"
+                  <%= if (Map.get(assoc.loaded_associations, assoc[:name]) || []) |> Enum.find(fn l -> Map.get(l, :name) == Map.get(a, :display) || Map.get(l, :type) == Map.get(a, :display) end) do "checked" end%>
+                >
+                  <%= Map.get(a, :display) |> String.capitalize() %>
+                </option>
+              <% end %>
+            </select>
+          <%= else %>
+            <%= for a <- assoc[:associations] do %>
+              <input
+                type="checkbox"
+                id="<%=element.schema_name%>_<%=assoc[:name]%>_<%=String.split(Map.get(a, :display)) |> Enum.join |> Macro.underscore()%>"
+                name="<%=element.schema_name%>[<%=assoc[:name]%>][<%=String.to_atom(Map.get(a, :display))%>]"
+                class="form-control"
+                <%= if (Map.get(assoc.loaded_associations, assoc[:name]) || []) |> Enum.find(fn l -> Map.get(l, :name) == Map.get(a, :display) || Map.get(l, :type) == Map.get(a, :display) end) do "checked" end%>
+                >
+              <label for="<%=element.schema_name%>_<%=assoc[:name]%>_<%=String.to_atom(Map.get(a, :display))%>"><%= Map.get(a, :display) |> String.capitalize() %></label>
+            <% end %>
           <% end %>
         </div>
       <% end %>

--- a/lib/templates/custom/custom.html.eex
+++ b/lib/templates/custom/custom.html.eex
@@ -8,15 +8,9 @@
           <%= if Map.has_key?(element, :input_first) && Enum.any?(element.input_first, &(&1 == field)) do %>
             <%= input f, field, element.schema_name, class: "form-control", required: (field in element.required), value: Map.get(@changeset.data, field) %>
             <%= error_tag f, field %>
-            <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %>
-              <% custom_label = Map.get(element.custom_labels, field) %>
-              <%= custom_label || humanize(field) %>
-            <% end %>
+            <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %><%=Map.get(element.custom_labels, field, humanize(field))%><% end %>
           <% else %>
-            <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %>
-              <% custom_label = Map.get(element.custom_labels, field) %>
-              <%= custom_label || humanize(field) %>
-            <% end %>
+            <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %><%=Map.get(element.custom_labels, field, humanize(field))%><% end %>
             <%= input f, field, element.schema_name, class: "form-control", required: (field in element.required), value: Map.get(@changeset.data, field) %>
             <%= error_tag f, field %>
           <% end %>
@@ -24,7 +18,7 @@
       <% end %>
       <%= for assoc <- element.associations do %>
         <div class="form-group <%= assoc[:name] %>-group">
-          <%= label String.to_existing_atom(element.schema_name), assoc[:name], class: "control-label" %>
+          <%= label String.to_existing_atom(element.schema_name), assoc[:name], class: "control-label #{if assoc[:name] in element.required do "required" end}" %>
           <%= if assoc[:cardinality] == :one do %>
             <select name="<%=element.schema_name%>[<%=assoc[:name]%>]">
               <%= for a <- assoc[:associations] do %>
@@ -47,6 +41,7 @@
               <label for="<%=element.schema_name%>_<%=assoc[:name]%>_<%=String.to_atom(Map.get(a, :display))%>"><%= Map.get(a, :display) |> String.capitalize() %></label>
             <% end %>
           <% end %>
+          <%= error_tag f, assoc[:name] %>
         </div>
       <% end %>
     <% end %>

--- a/lib/templates/custom/custom.html.eex
+++ b/lib/templates/custom/custom.html.eex
@@ -6,7 +6,7 @@
       <%= for field <- element.fields do %>
         <div class="form-group">
           <%= if Map.has_key?(element, :input_first) && Enum.any?(element.input_first, &(&1 == field)) do %>
-            <%= input f, field, element.schema_name, class: "form-control", required: (field in element.required) %>
+            <%= input f, field, element.schema_name, class: "form-control", required: (field in element.required), value: Map.get(@changeset.data, field) %>
             <%= error_tag f, field %>
             <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %>
               <% custom_label = Map.get(element.custom_labels, field) %>
@@ -17,7 +17,7 @@
               <% custom_label = Map.get(element.custom_labels, field) %>
               <%= custom_label || humanize(field) %>
             <% end %>
-            <%= input f, field, element.schema_name, class: "form-control", required: (field in element.required) %>
+            <%= input f, field, element.schema_name, class: "form-control", required: (field in element.required), value: Map.get(@changeset.data, field) %>
             <%= error_tag f, field %>
           <% end %>
         </div>
@@ -29,7 +29,7 @@
             <select name="<%=element.schema_name%>[<%=assoc[:name]%>]">
               <%= for a <- assoc[:associations] do %>
                 <option value="<%=String.to_atom(Map.get(a, :display))%>"
-                  <%= if (Map.get(assoc.loaded_associations, assoc[:name]) || []) |> Enum.find(fn l -> Map.get(l, :name) == Map.get(a, :display) || Map.get(l, :type) == Map.get(a, :display) end) do "checked" end%>
+                  <%= if (Map.get(assoc.loaded_associations, assoc[:name]) || %{}) |> Map.get(:name) == Map.get(a, :display) do "selected" end%>
                 >
                   <%= Map.get(a, :display) |> String.capitalize() %>
                 </option>


### PR DESCRIPTION
- Displays single choice associations (belongs_to) as a select element instead of checkboxes. #11 
- Fixes a few small bugs regarding changesets not being passed to update forms correctly.
