### PR TITLE
Input default opts

### DIFF
--- a/lib/views/custom_view.ex
+++ b/lib/views/custom_view.ex
@@ -15,6 +15,16 @@ defmodule Autoform.CustomView do
           Phoenix.HTML.Form.input_type(form, field)
       end
 
+    # Apply any sensible defaults here, but we should allow configuration of individual input options
+    opts =
+      Keyword.merge(
+        opts,
+        case schema.__schema__(:type, field) do
+          :float -> [step: 0.01]
+          _ -> []
+        end
+      )
+
     apply(Phoenix.HTML.Form, type, [String.to_existing_atom(name), field, opts])
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Autoform.MixProject do
   def project do
     [
       app: :autoform,
-      version: "0.4.0",
+      version: "0.5.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/custom_test.exs
+++ b/test/custom_test.exs
@@ -92,4 +92,16 @@ defmodule CustomTest do
       assert response =~ "textarea"
     end
   end
+
+  describe "Product" do
+    test "renders number input with step of 0.01", %{conn: conn} do
+      assert response =
+               conn
+               |> get(custom_path(conn, :new_product))
+               |> html_response(200)
+
+      assert response =~ "type=\"number\""
+      assert response =~ "step=\"0.01\""
+    end
+  end
 end

--- a/test/support/test_autoform/lib/test_autoform/product.ex
+++ b/test/support/test_autoform/lib/test_autoform/product.ex
@@ -1,0 +1,17 @@
+defmodule TestAutoform.Product do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "products" do
+    field(:price, :float)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(product, attrs) do
+    product
+    |> cast(attrs, [:price])
+    |> validate_required([:price])
+  end
+end

--- a/test/support/test_autoform/lib/test_autoform_web/controllers/custom_controller.ex
+++ b/test/support/test_autoform/lib/test_autoform_web/controllers/custom_controller.ex
@@ -1,6 +1,6 @@
 defmodule TestAutoformWeb.CustomController do
   use TestAutoformWeb, :controller
-  alias TestAutoform.Address
+  alias TestAutoform.{Address, Product}
 
   def new(conn, _params) do
     changeset = Address.changeset(%Address{}, %{})
@@ -12,5 +12,11 @@ defmodule TestAutoformWeb.CustomController do
     changeset = Address.changeset(%Address{}, %{})
 
     render(conn, "new_no_path.html", changeset: changeset)
+  end
+
+  def new_product(conn, _params) do
+    changeset = Product.changeset(%Product{}, %{})
+
+    render(conn, "new_product.html", changeset: changeset)
   end
 end

--- a/test/support/test_autoform/lib/test_autoform_web/router.ex
+++ b/test/support/test_autoform/lib/test_autoform_web/router.ex
@@ -21,6 +21,7 @@ defmodule TestAutoformWeb.Router do
     resources("/addresses", AddressController)
     resources("/custom", CustomController)
     get("/custom_no_path", CustomController, :new_no_path)
+    get("/custom_new_product", CustomController, :new_product)
   end
 
   # Other scopes may use custom stacks.

--- a/test/support/test_autoform/lib/test_autoform_web/templates/custom/new_product.html.eex
+++ b/test/support/test_autoform/lib/test_autoform_web/templates/custom/new_product.html.eex
@@ -1,0 +1,1 @@
+<%= custom_render_autoform(@conn, :create, [TestAutoform.Product]) %>


### PR DESCRIPTION
Adds default options to html input elements based on the schema type. 

Currently adds `step: 0.01` to number inputs if the type is `:float`. (https://github.com/club-soda/club-soda-guide/issues/107)

While this should be used to apply sensible default options, in the long run it would be best to allow these to be configurable, as well as drawing them from [Fields](https://github.com/dwyl/fields) in some way.