### PR TITLE
Changeset data

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ custom_render_autoform(conn, action, [{schema, opts}], options)
 
 If you don't want the associations to be rendered in your form, you can add them to your exclude list (see options `above`).
 
+If you are using the `custom_render_autoform` function and one of the schemas you pass in is an association of the `changeset`'s schema, it will be rendered within an `inputs_for` call, so your changes and any errors will be correctly rendered in the form.
+
 ### Fields
 
 This module can be used in conjuction with https://github.com/dwyl/fields.

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -182,10 +182,13 @@ defmodule Autoform do
           Keyword.get(options, :assigns, [])
           |> Map.new()
           |> Map.put_new(:changeset, first_schema.changeset(struct(first_schema), %{}))
-          |> Map.merge(%{
-            elements: element_assigns,
-            action: Keyword.get(options, :path, path(conn, action, first_schema, options))
-          })
+          |> (fn m ->
+                Map.merge(m, %{
+                  elements: element_assigns,
+                  action: Keyword.get(options, :path, path(conn, action, first_schema, options)),
+                  assoc_list: Map.get(m, :changeset).data.__struct__.__schema__(:associations)
+                })
+              end).()
         )
       end
 

--- a/lib/templates/custom/custom.html.eex
+++ b/lib/templates/custom/custom.html.eex
@@ -3,18 +3,36 @@
     <%= if html = Map.get(element, :html) do %>
       <%= html %>
     <% else %>
-      <%= for field <- element.fields do %>
-        <div class="form-group">
-          <%= if Map.has_key?(element, :input_first) && Enum.any?(element.input_first, &(&1 == field)) do %>
-            <%= input f, field, element.schema_name, element.schema, class: "form-control", required: (field in element.required), value: Map.get(@changeset.data, field) %>
-            <%= error_tag f, field %>
-            <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %><%=Map.get(element.custom_labels, field, humanize(field))%><% end %>
-          <% else %>
-            <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %><%=Map.get(element.custom_labels, field, humanize(field))%><% end %>
-            <%= input f, field, element.schema_name, element.schema, class: "form-control", required: (field in element.required), value: Map.get(@changeset.data, field) %>
-            <%= error_tag f, field %>
+      <%= if element.schema_name == "user" do %>
+        <%= inputs_for f, :user, fn p -> %>
+          <%= for field <- element.fields do %>
+            <div class="form-group">
+              <%= if Map.has_key?(element, :input_first) && Enum.any?(element.input_first, &(&1 == field)) do %>
+                <%= input p, field, element.schema, class: "form-control", required: (field in element.required), value: Map.get(@changeset.data, field) %>
+                <%= error_tag p, field %>
+                <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %><%=Map.get(element.custom_labels, field, humanize(field))%><% end %>
+              <% else %>
+                <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %><%=Map.get(element.custom_labels, field, humanize(field))%><% end %>
+                <%= input p, field, element.schema, class: "form-control", required: (field in element.required), value: Map.get(@changeset.data, field) %>
+                <%= error_tag p, field %>
+              <% end %>
+            </div>
           <% end %>
-        </div>
+        <% end %>
+      <% else %>
+        <%= for field <- element.fields do %>
+          <div class="form-group">
+            <%= if Map.has_key?(element, :input_first) && Enum.any?(element.input_first, &(&1 == field)) do %>
+              <%= input f, field, element.schema, class: "form-control", required: (field in element.required), value: Map.get(@changeset.data, field) %>
+              <%= error_tag f, field %>
+              <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %><%=Map.get(element.custom_labels, field, humanize(field))%><% end %>
+            <% else %>
+              <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %><%=Map.get(element.custom_labels, field, humanize(field))%><% end %>
+              <%= input f, field, element.schema, class: "form-control", required: (field in element.required), value: Map.get(@changeset.data, field) %>
+              <%= error_tag f, field %>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
       <%= for assoc <- element.associations do %>
         <div class="form-group <%= assoc[:name] %>-group">

--- a/lib/templates/custom/custom.html.eex
+++ b/lib/templates/custom/custom.html.eex
@@ -3,36 +3,12 @@
     <%= if html = Map.get(element, :html) do %>
       <%= html %>
     <% else %>
-      <%= if element.schema_name == "user" do %>
+      <%= if String.to_existing_atom(element.schema_name) in @assoc_list do %>
         <%= inputs_for f, :user, fn p -> %>
-          <%= for field <- element.fields do %>
-            <div class="form-group">
-              <%= if Map.has_key?(element, :input_first) && Enum.any?(element.input_first, &(&1 == field)) do %>
-                <%= input p, field, element.schema, class: "form-control", required: (field in element.required), value: Map.get(@changeset.data, field) %>
-                <%= error_tag p, field %>
-                <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %><%=Map.get(element.custom_labels, field, humanize(field))%><% end %>
-              <% else %>
-                <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %><%=Map.get(element.custom_labels, field, humanize(field))%><% end %>
-                <%= input p, field, element.schema, class: "form-control", required: (field in element.required), value: Map.get(@changeset.data, field) %>
-                <%= error_tag p, field %>
-              <% end %>
-            </div>
-          <% end %>
+          <%= render "field_inputs.html", element: element, f: p, changeset: @changeset %>
         <% end %>
       <% else %>
-        <%= for field <- element.fields do %>
-          <div class="form-group">
-            <%= if Map.has_key?(element, :input_first) && Enum.any?(element.input_first, &(&1 == field)) do %>
-              <%= input f, field, element.schema, class: "form-control", required: (field in element.required), value: Map.get(@changeset.data, field) %>
-              <%= error_tag f, field %>
-              <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %><%=Map.get(element.custom_labels, field, humanize(field))%><% end %>
-            <% else %>
-              <%= label String.to_existing_atom(element.schema_name), field, class: "control-label #{if field in element.required do "required" end}" do %><%=Map.get(element.custom_labels, field, humanize(field))%><% end %>
-              <%= input f, field, element.schema, class: "form-control", required: (field in element.required), value: Map.get(@changeset.data, field) %>
-              <%= error_tag f, field %>
-            <% end %>
-          </div>
-        <% end %>
+        <%= render "field_inputs.html", element: element, f: f, changeset: @changeset %>
       <% end %>
       <%= for assoc <- element.associations do %>
         <div class="form-group <%= assoc[:name] %>-group">

--- a/lib/templates/custom/field_inputs.html.eex
+++ b/lib/templates/custom/field_inputs.html.eex
@@ -3,9 +3,9 @@
     <%= if Map.has_key?(@element, :input_first) && Enum.any?(@element.input_first, &(&1 == field)) do %>
       <%= input @f, field, @element.schema, class: "form-control", required: (field in @element.required), value: Map.get(@changeset.data, field) %>
       <%= error_tag @f, field %>
-      <%= label String.to_existing_atom(@element.schema_name), field, class: "control-label #{if field in @element.required do "required" end}" do %><%=Map.get(@element.custom_labels, field, humanize(field))%><% end %>
+      <%= label @f, field, class: "control-label #{if field in @element.required do "required" end}" do %><%=Map.get(@element.custom_labels, field, humanize(field))%><% end %>
     <% else %>
-      <%= label String.to_existing_atom(@element.schema_name), field, class: "control-label #{if field in @element.required do "required" end}" do %><%=Map.get(@element.custom_labels, field, humanize(field))%><% end %>
+      <%= label @f, field, class: "control-label #{if field in @element.required do "required" end}" do %><%=Map.get(@element.custom_labels, field, humanize(field))%><% end %>
       <%= input @f, field, @element.schema, class: "form-control", required: (field in @element.required), value: Map.get(@changeset.data, field) %>
       <%= error_tag @f, field %>
     <% end %>

--- a/lib/templates/custom/field_inputs.html.eex
+++ b/lib/templates/custom/field_inputs.html.eex
@@ -1,0 +1,13 @@
+<%= for field <- @element.fields do %>
+  <div class="form-group">
+    <%= if Map.has_key?(@element, :input_first) && Enum.any?(@element.input_first, &(&1 == field)) do %>
+      <%= input @f, field, @element.schema, class: "form-control", required: (field in @element.required), value: Map.get(@changeset.data, field) %>
+      <%= error_tag @f, field %>
+      <%= label String.to_existing_atom(@element.schema_name), field, class: "control-label #{if field in @element.required do "required" end}" do %><%=Map.get(@element.custom_labels, field, humanize(field))%><% end %>
+    <% else %>
+      <%= label String.to_existing_atom(@element.schema_name), field, class: "control-label #{if field in @element.required do "required" end}" do %><%=Map.get(@element.custom_labels, field, humanize(field))%><% end %>
+      <%= input @f, field, @element.schema, class: "form-control", required: (field in @element.required), value: Map.get(@changeset.data, field) %>
+      <%= error_tag @f, field %>
+    <% end %>
+  </div>
+<% end %>

--- a/lib/views/custom_view.ex
+++ b/lib/views/custom_view.ex
@@ -4,7 +4,7 @@ defmodule Autoform.CustomView do
   import Phoenix.HTML.Form
   import Autoform.ErrorHelpers
 
-  def input(form, field, name, schema, opts) do
+  def input(form, field, schema, opts) do
     type =
       with "Elixir.Fields." <> field_type <- to_string(schema.__schema__(:type, field)),
            {:module, module} <- Code.ensure_loaded(Module.concat(Fields, field_type)),
@@ -19,12 +19,13 @@ defmodule Autoform.CustomView do
     opts =
       Keyword.merge(
         opts,
-        case schema.__schema__(:type, field) do
-          :float -> [step: 0.01]
-          _ -> []
-        end
+        [value: form.source.changes[field]] ++
+          case schema.__schema__(:type, field) do
+            :float -> [step: 0.01]
+            _ -> []
+          end
       )
 
-    apply(Phoenix.HTML.Form, type, [String.to_existing_atom(name), field, opts])
+    apply(Phoenix.HTML.Form, type, [form, field, opts])
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Autoform.MixProject do
   def project do
     [
       app: :autoform,
-      version: "0.5.0",
+      version: "0.6.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
- Changes are rendered in the form when the page reloads, for example if there's a validation error
- Nested changesets are now rendered inside `inputs_for`, so their changes will also display correctly

Allows us to use two schemas in one form, as required for: https://github.com/club-soda/club-soda-guide/issues/25