### PR TITLE
Changeset fixes

### DIFF
--- a/lib/templates/custom/custom.html.eex
+++ b/lib/templates/custom/custom.html.eex
@@ -3,8 +3,8 @@
     <%= if html = Map.get(element, :html) do %>
       <%= html %>
     <% else %>
-      <%= if String.to_existing_atom(element.schema_name) in @assoc_list do %>
-        <%= inputs_for f, :user, fn p -> %>
+      <%= if assoc_schema = one_of([String.to_existing_atom(element.schema_name), String.to_existing_atom(element.schema_name <> "s")],  @assoc_list) do %>
+        <%= inputs_for f, assoc_schema, fn p -> %>
           <%= render "field_inputs.html", element: element, f: p, changeset: @changeset %>
         <% end %>
       <% else %>

--- a/lib/templates/custom/custom.html.eex
+++ b/lib/templates/custom/custom.html.eex
@@ -3,7 +3,7 @@
     <%= if html = Map.get(element, :html) do %>
       <%= html %>
     <% else %>
-      <%= if assoc_schema = one_of([String.to_existing_atom(element.schema_name), String.to_existing_atom(element.schema_name <> "s")],  @assoc_list) do %>
+      <%= if assoc_schema = one_of([String.to_existing_atom(element.schema_name), element.schema.__schema__(:source)],  @assoc_list) do %>
         <%= inputs_for f, assoc_schema, fn p -> %>
           <%= render "field_inputs.html", element: element, f: p, changeset: @changeset %>
         <% end %>

--- a/lib/views/custom_view.ex
+++ b/lib/views/custom_view.ex
@@ -33,4 +33,10 @@ defmodule Autoform.CustomView do
 
     apply(Phoenix.HTML.Form, type, [form, field, opts])
   end
+
+  def one_of(list_1, list_2) do
+    Enum.reduce(list_1, nil, fn el, acc ->
+      if el in list_2, do: el
+    end)
+  end
 end

--- a/lib/views/custom_view.ex
+++ b/lib/views/custom_view.ex
@@ -17,13 +17,18 @@ defmodule Autoform.CustomView do
 
     # Apply any sensible defaults here, but we should allow configuration of individual input options
     opts =
-      Keyword.merge(
-        opts,
-        [value: form.source.changes[field]] ++
-          case schema.__schema__(:type, field) do
-            :float -> [step: 0.01]
-            _ -> []
-          end
+      opts
+      |> Keyword.merge(
+        case schema.__schema__(:type, field) do
+          :float -> [step: 0.01]
+          _ -> []
+        end
+      )
+      |> Keyword.merge(
+        cond do
+          map_size(form.source.changes) > 0 -> [value: form.source.changes[field]]
+          true -> []
+        end
       )
 
     apply(Phoenix.HTML.Form, type, [form, field, opts])


### PR DESCRIPTION
Small bugs left over from #32 
- `inputs_for` renders for many-to-many relationships as well as many-to-one
- change data is only used in form if it actually exists