### PR TITLE
gets schema source as atom

### DIFF
--- a/lib/templates/custom/custom.html.eex
+++ b/lib/templates/custom/custom.html.eex
@@ -3,7 +3,7 @@
     <%= if html = Map.get(element, :html) do %>
       <%= html %>
     <% else %>
-      <%= if assoc_schema = one_of([String.to_existing_atom(element.schema_name), element.schema.__schema__(:source)],  @assoc_list) do %>
+      <%= if assoc_schema = one_of([String.to_existing_atom(element.schema_name), String.to_atom(element.schema.__schema__(:source))],  @assoc_list) do %>
         <%= inputs_for f, assoc_schema, fn p -> %>
           <%= render "field_inputs.html", element: element, f: p, changeset: @changeset %>
         <% end %>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Autoform.MixProject do
   def project do
     [
       app: :autoform,
-      version: "0.6.0",
+      version: "0.6.1",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Small bugfix:
- `assoc_schema` is coming through as an atom, so we need to convert the `:source` to match it.