### PR TITLE
Format schema name

### DIFF
--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -278,7 +278,7 @@ defmodule Autoform do
       end
 
       defp schema_name(schema) do
-        schema |> to_string() |> String.split(".") |> List.last()
+        schema |> to_string() |> Macro.underscore() |> String.split(".") |> List.last()
       end
 
       defp submit_btn_txt(assigns, options) do


### PR DESCRIPTION
ref: https://github.com/dwyl/autoform/issues/36#issuecomment-449494792

make sure to use the right naming format for schemas by using `Macro.underscore` function
