### PR TITLE
Schema underscore

### DIFF
--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -278,7 +278,7 @@ defmodule Autoform do
       end
 
       defp schema_name(schema) do
-        schema |> to_string() |> Macro.underscore() |>String.split(".") |> List.last()
+        schema |> to_string() |> String.downcase() | String.split(".") |> List.last()
       end
 
       defp submit_btn_txt(assigns, options) do

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -278,15 +278,7 @@ defmodule Autoform do
       end
 
       defp schema_name(schema) do
-        IO.inspect "*************************"
-        IO.inspect schema
-        IO.inspect "*************************"
-        IO.inspect schema |> to_string() |> String.downcase() |> String.split(".") |> List.last()
-        IO.inspect "*************************"
-        IO.inspect "*************************"
-
-        name = schema |> to_string() |> String.downcase() |> String.split(".") |> List.last()
-        name <> "modtest"
+        schema |> to_string() |> String.split(".") |> List.last() |> Macro.underscore()
       end
 
       defp submit_btn_txt(assigns, options) do

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -278,7 +278,7 @@ defmodule Autoform do
       end
 
       defp schema_name(schema) do
-        schema |> to_string() |> Macro.underscore() |> String.split(".") |> List.last()
+        schema |> to_string() |> String.split(".") |> List.last()
       end
 
       defp submit_btn_txt(assigns, options) do

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -278,7 +278,7 @@ defmodule Autoform do
       end
 
       defp schema_name(schema) do
-        schema |> to_string() |> String.split(".") |> List.last()
+        schema |> to_string() |> Macro.underscore() |>String.split(".") |> List.last()
       end
 
       defp submit_btn_txt(assigns, options) do

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -278,7 +278,7 @@ defmodule Autoform do
       end
 
       defp schema_name(schema) do
-        schema |> to_string() |> String.downcase() | String.split(".") |> List.last()
+        schema |> to_string() |> String.downcase() |> String.split(".") |> List.last()
       end
 
       defp submit_btn_txt(assigns, options) do

--- a/lib/autoform.ex
+++ b/lib/autoform.ex
@@ -278,7 +278,15 @@ defmodule Autoform do
       end
 
       defp schema_name(schema) do
-        schema |> to_string() |> String.downcase() |> String.split(".") |> List.last()
+        IO.inspect "*************************"
+        IO.inspect schema
+        IO.inspect "*************************"
+        IO.inspect schema |> to_string() |> String.downcase() |> String.split(".") |> List.last()
+        IO.inspect "*************************"
+        IO.inspect "*************************"
+
+        name = schema |> to_string() |> String.downcase() |> String.split(".") |> List.last()
+        name <> "modtest"
       end
 
       defp submit_btn_txt(assigns, options) do

--- a/lib/templates/custom/custom.html.eex
+++ b/lib/templates/custom/custom.html.eex
@@ -19,7 +19,7 @@
                 <option value="<%=String.to_atom(Map.get(a, :display))%>"
                   <%= if (Map.get(assoc.loaded_associations, assoc[:name]) || %{}) |> Map.get(:name) == Map.get(a, :display) do "selected" end%>
                 >
-                  <%= Map.get(a, :display) |> String.capitalize() %>
+                  <%= Map.get(a, :display) %>
                 </option>
               <% end %>
             </select>
@@ -32,7 +32,7 @@
                 class="form-control"
                 <%= if (Map.get(assoc.loaded_associations, assoc[:name]) || []) |> Enum.find(fn l -> Map.get(l, :name) == Map.get(a, :display) || Map.get(l, :type) == Map.get(a, :display) end) do "checked" end%>
                 >
-              <label for="<%=element.schema_name%>_<%=assoc[:name]%>_<%=String.to_atom(Map.get(a, :display))%>"><%= Map.get(a, :display) |> String.capitalize() %></label>
+              <label for="<%=element.schema_name%>_<%=assoc[:name]%>_<%=String.to_atom(Map.get(a, :display))%>"><%= Map.get(a, :display) %></label>
             <% end %>
           <% end %>
           <%= error_tag f, assoc[:name] %>

--- a/lib/templates/custom/custom.html.eex
+++ b/lib/templates/custom/custom.html.eex
@@ -19,7 +19,7 @@
                 <option value="<%=String.to_atom(Map.get(a, :display))%>"
                   <%= if (Map.get(assoc.loaded_associations, assoc[:name]) || %{}) |> Map.get(:name) == Map.get(a, :display) do "selected" end%>
                 >
-                  <%= Map.get(a, :display) %>
+                  <%= Map.get(a, :display) |> String.capitalize() %>
                 </option>
               <% end %>
             </select>
@@ -32,7 +32,7 @@
                 class="form-control"
                 <%= if (Map.get(assoc.loaded_associations, assoc[:name]) || []) |> Enum.find(fn l -> Map.get(l, :name) == Map.get(a, :display) || Map.get(l, :type) == Map.get(a, :display) end) do "checked" end%>
                 >
-              <label for="<%=element.schema_name%>_<%=assoc[:name]%>_<%=String.to_atom(Map.get(a, :display))%>"><%= Map.get(a, :display) %></label>
+              <label for="<%=element.schema_name%>_<%=assoc[:name]%>_<%=String.to_atom(Map.get(a, :display))%>"><%= Map.get(a, :display) |> String.capitalize() %></label>
             <% end %>
           <% end %>
           <%= error_tag f, assoc[:name] %>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Autoform.MixProject do
   def project do
     [
       app: :autoform,
-      version: "0.6.1",
+      version: "0.6.4",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/autoform_controller_test.exs
+++ b/test/autoform_controller_test.exs
@@ -71,5 +71,14 @@ defmodule AutoformControllerTest do
 
       refute response =~ "age"
     end
+
+    test "multipe words schema", %{conn: conn} do
+      assert response =
+               conn
+               |> get(do_what_you_love_path(conn, :new))
+               |> html_response(200)
+
+      assert response =~ "do_what_you_love_name"
+    end
   end
 end

--- a/test/support/test_autoform/lib/test_autoform/DoWhatYouLove.ex
+++ b/test/support/test_autoform/lib/test_autoform/DoWhatYouLove.ex
@@ -1,0 +1,17 @@
+defmodule TestAutoform.DoWhatYouLove do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "do_what_you_love" do
+    field(:name, :string)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(user, attrs) do
+    user
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+  end
+end

--- a/test/support/test_autoform/lib/test_autoform_web/controllers/do_what_you_love_controller.ex
+++ b/test/support/test_autoform/lib/test_autoform_web/controllers/do_what_you_love_controller.ex
@@ -1,0 +1,13 @@
+defmodule TestAutoformWeb.DoWhatYouLoveController do
+  use TestAutoformWeb, :controller
+  use Autoform
+
+  alias TestAutoform.DoWhatYouLove
+
+  def new(conn, _params) do
+    changeset = DoWhatYouLove.changeset(%DoWhatYouLove{}, %{})
+
+    render_autoform(conn, :create, DoWhatYouLove, assigns: [changeset: changeset])
+  end
+
+end

--- a/test/support/test_autoform/lib/test_autoform_web/router.ex
+++ b/test/support/test_autoform/lib/test_autoform_web/router.ex
@@ -23,6 +23,7 @@ defmodule TestAutoformWeb.Router do
     resources("/sample_products", SampleProductController)
     get("/custom_no_path", CustomController, :new_no_path)
     get("/custom_new_product", CustomController, :new_product)
+    resources("/do_what_you_love", DoWhatYouLoveController)
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
ref: https://github.com/dwyl/autoform/issues/36#issuecomment-449565954

Use `Macro.underscore` after `split(".") to avoid having . converted to / and show up in the schema name